### PR TITLE
Opravit změnu měsíce pro datum (29.), 30. a 31. ledna

### DIFF
--- a/ClientApp/KachnaOnline/src/app/shared/components/month-selection/month-selection.component.ts
+++ b/ClientApp/KachnaOnline/src/app/shared/components/month-selection/month-selection.component.ts
@@ -21,6 +21,7 @@ export class MonthSelectionComponent implements OnInit {
   }
 
   changeMonth(delta: number) {
+    this.month.setDate(1);
     this.month.setMonth(this.month.getMonth() + delta);
     this.monthChange.emit(this.month);
   }


### PR DESCRIPTION
Když je 30. nebo 31. ledna, tak tlačítko pro změnu měsíce ve směru dopředu skočí rovnou na březen. V nepřestupné roky se toto děje i 29. ledna.

Prosím, zkuste to otestovat před nasazením, na JS jsem dlouho nesahal. ;)